### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/taolearning/dba91741-744d-4a80-aedc-498eccd44b7c/86d54574-f428-4f44-9716-7db4077ec872/_apis/work/boardbadge/e9a2fb0b-b73b-40ab-b977-2a15f5a91118)](https://dev.azure.com/taolearning/dba91741-744d-4a80-aedc-498eccd44b7c/_boards/board/t/86d54574-f428-4f44-9716-7db4077ec872/Microsoft.RequirementCategory)
 # Agile Intelligence
 Automating the Social Interaction and Communication for Organizations
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#44](https://dev.azure.com/taolearning/dba91741-744d-4a80-aedc-498eccd44b7c/_workitems/edit/44). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.